### PR TITLE
 DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleCommentResponse.java
+++ b/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.boardservice.domain.dto.response;
 
 import com.fastcampus.boardservice.domain.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -10,7 +9,7 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname) implements Serializable {
+        String nickname)  {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleResponse.java
+++ b/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.boardservice.domain.dto.response;
 
 import com.fastcampus.boardservice.domain.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+)  {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleWithCommentsResponse.java
+++ b/fastcampus-board-service/src/main/java/com/fastcampus/boardservice/domain/dto/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.boardservice.domain.dto.response;
 
 import com.fastcampus.boardservice.domain.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+)  {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 implements Serializable 이 들어가버림
우리 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제