### PR TITLE
해시태그 메뉴를 헤더에 추가

### DIFF
--- a/fastcampus-board-service/src/main/resources/templates/header.html
+++ b/fastcampus-board-service/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
             </ul>
 
             <div class="text-end">

--- a/fastcampus-board-service/src/main/resources/templates/header.th.xml
+++ b/fastcampus-board-service/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
https://github.com/djkeh/fastcampus-project-board/issues/38 에서 투가한 기능을 헤더 메뉴에 노출시키는 부분을 구현

This closes #41 